### PR TITLE
Quick drive input parity with normal drive

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -9422,7 +9422,8 @@ void SetAction(byte8* actorBaseAddr) {
         if (activeCrimsonGameplay.Gameplay.Dante.driveRework &&
             ExpConfig::missionExpDataDante.unlocks[UNLOCK_DANTE::REBELLION_DRIVE] &&
             (wasRebellionAttack) && (demo_pl000_00_3 != 0) &&
-            (actorData.action == REBELLION_STINGER_LEVEL_2 || actorData.action == REBELLION_STINGER_LEVEL_1) &&
+            (actorData.action == REBELLION_STINGER_LEVEL_2 || actorData.action == REBELLION_STINGER_LEVEL_1 ||
+                action == REBELLION_COMBO_1_PART_1) &&
             b2F.forwardCommand) {
             actorData.action = REBELLION_DRIVE_1;
 


### PR DESCRIPTION
adds rebellion part 1 to quick drive's move checklist so you don't have to hold forward to use quick drive.